### PR TITLE
Handle nested arrays in CurlyListNode

### DIFF
--- a/packages/BetterPhpDocParser/ValueObject/PhpDoc/DoctrineAnnotation/CurlyListNode.php
+++ b/packages/BetterPhpDocParser/ValueObject/PhpDoc/DoctrineAnnotation/CurlyListNode.php
@@ -33,6 +33,9 @@ final class CurlyListNode extends AbstractValuesAwareNode implements Stringable
         return (string) $value;
     }
     
+    /**
+     * @param mixed[] $array
+     */
     private function implode(array $array): string
     {
         $itemContents = '';

--- a/packages/BetterPhpDocParser/ValueObject/PhpDoc/DoctrineAnnotation/CurlyListNode.php
+++ b/packages/BetterPhpDocParser/ValueObject/PhpDoc/DoctrineAnnotation/CurlyListNode.php
@@ -10,22 +10,7 @@ final class CurlyListNode extends AbstractValuesAwareNode implements Stringable
 {
     public function __toString(): string
     {
-        $itemContents = '';
-        $lastItemKey = array_key_last($this->values);
-
-        foreach ($this->values as $key => $value) {
-            if (is_int($key)) {
-                $itemContents .= $this->stringifyValue($value);
-            } else {
-                $itemContents .= $key . '=' . $this->stringifyValue($value);
-            }
-
-            if ($lastItemKey !== $key) {
-                $itemContents .= ', ';
-            }
-        }
-
-        return '{' . $itemContents . '}';
+        return $this->implode($this->values);
     }
 
     /**
@@ -42,9 +27,29 @@ final class CurlyListNode extends AbstractValuesAwareNode implements Stringable
         }
 
         if (is_array($value)) {
-            return implode(', ', $value);
+            return $this->implode($value);
         }
 
         return (string) $value;
+    }
+    
+    private function implode(array $array): string
+    {
+        $itemContents = '';
+        $lastItemKey = array_key_last($array);
+
+        foreach ($array as $key => $value) {
+            if (is_int($key)) {
+                $itemContents .= $this->stringifyValue($value);
+            } else {
+                $itemContents .= $key . '=' . $this->stringifyValue($value);
+            }
+
+            if ($lastItemKey !== $key) {
+                $itemContents .= ', ';
+            }
+        }
+
+        return '{' . $itemContents . '}';
     }
 }


### PR DESCRIPTION
Prevents `Array to string conversion` errors, and the resulting `Array` string in transformed curly lists instead of the expected nested array values.

Source:
```php
/**
 * @ApiResource(
 *      mercure=true,
 *      graphql={
 *         "item_query",
 *         "update",
 *         "transition"={
 *             "denormalization_context"={"groups"={"transition"}},
 *             "security"="is_granted('transition',object)",
 *             "mutation"=VmTransitionResolver::class,
 *             "deserialize"=false,
 *             "args"={"id"={"type"="ID!"}, "state"={"type"="String!"}}
 *         }
 *     }
 * )
 */
```

Incorrect:
```php
/**
 * @ApiResource(mercure=true, graphql={"item_query", "update", "transition"=Array, "is_granted('transition',object)", VmTransitionResolver::class, false, Array})
 */
```

Correct:
```php
/**
 * @ApiResource(mercure=true, graphql={"item_query", "update", "transition"={"denormalization_context"={"groups"={"transition"}}, "security"="is_granted('transition',object)", "mutation"=VmTransitionResolver::class, "deserialize"=false, "args"={"id"={"type"="ID!"}, "state"={"type"="String!"}}}})
 */
```